### PR TITLE
Change links from AnalyticalGraphicsInc to CesiumGS

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,66 +3,66 @@ Change Log
 
 ### 3.?.? ????-??-??
 
-* Added back `inputUpAxis` and `outputUpAxis`. [#211](https://github.com/AnalyticalGraphicsInc/obj2gltf/pull/211)
-* Fixed handling of mtl and texture absolute paths. [#219](https://github.com/AnalyticalGraphicsInc/obj2gltf/pull/219)
-* Fixed specular image not being decoded when referenced by other textures. [#217](https://github.com/AnalyticalGraphicsInc/obj2gltf/pull/217)
-* Fixed parsing faces that reference non-existing attributes. [#218](https://github.com/AnalyticalGraphicsInc/obj2gltf/pull/218)
+* Added back `inputUpAxis` and `outputUpAxis`. [#211](https://github.com/CesiumGS/obj2gltf/pull/211)
+* Fixed handling of mtl and texture absolute paths. [#219](https://github.com/CesiumGS/obj2gltf/pull/219)
+* Fixed specular image not being decoded when referenced by other textures. [#217](https://github.com/CesiumGS/obj2gltf/pull/217)
+* Fixed parsing faces that reference non-existing attributes. [#218](https://github.com/CesiumGS/obj2gltf/pull/218)
 
 ### 3.0.4 - 2019-07-22
 
-* No longer printing texture decode warning if the diffuse and alpha textures are the same. [#205](https://github.com/AnalyticalGraphicsInc/obj2gltf/pull/205)
+* No longer printing texture decode warning if the diffuse and alpha textures are the same. [#205](https://github.com/CesiumGS/obj2gltf/pull/205)
 
 ### 3.0.3 2019-06-26
 
-* Fixed parsing of negative face indices. [#191](https://github.com/AnalyticalGraphicsInc/obj2gltf/pull/191)
+* Fixed parsing of negative face indices. [#191](https://github.com/CesiumGS/obj2gltf/pull/191)
 
 ### 3.0.2 2019-03-21
 
-* Fixed a crash when saving separate resources that would exceed the Node buffer size limit. [#173](https://github.com/AnalyticalGraphicsInc/obj2gltf/pull/173)
+* Fixed a crash when saving separate resources that would exceed the Node buffer size limit. [#173](https://github.com/CesiumGS/obj2gltf/pull/173)
 
 ### 3.0.1 2019-03-08
 
-* Fixed handling of materials that don't have names. [#173](https://github.com/AnalyticalGraphicsInc/obj2gltf/pull/173)
+* Fixed handling of materials that don't have names. [#173](https://github.com/CesiumGS/obj2gltf/pull/173)
 
 ### 3.0.0 2018-12-05
 
 * Breaking changes
-    * The `--materialsCommon` flag has been removed. Use `--unlit` instead which uses the `KHR_materials_unlit` extension. [#152](https://github.com/AnalyticalGraphicsInc/obj2gltf/pull/152)
+    * The `--materialsCommon` flag has been removed. Use `--unlit` instead which uses the `KHR_materials_unlit` extension. [#152](https://github.com/CesiumGS/obj2gltf/pull/152)
 
 ### 2.3.2 2018-11-02
 
-* Improved handling of primitives with different attributes using the same material. Materials are now duplicated. [#162](https://github.com/AnalyticalGraphicsInc/obj2gltf/pull/162)
-* Fixed a bug where primitives without texture coordinates could use materials containing textures. Those textures are now removed. [#162](https://github.com/AnalyticalGraphicsInc/obj2gltf/pull/162)
-* Improved parsing of faces with mismatching attributes. [#161](https://github.com/AnalyticalGraphicsInc/obj2gltf/pull/161)
+* Improved handling of primitives with different attributes using the same material. Materials are now duplicated. [#162](https://github.com/CesiumGS/obj2gltf/pull/162)
+* Fixed a bug where primitives without texture coordinates could use materials containing textures. Those textures are now removed. [#162](https://github.com/CesiumGS/obj2gltf/pull/162)
+* Improved parsing of faces with mismatching attributes. [#161](https://github.com/CesiumGS/obj2gltf/pull/161)
 
 ### 2.3.1 2018-10-16
 
-* Improved parsing models with concave or n-sided faces. [#157](https://github.com/AnalyticalGraphicsInc/obj2gltf/pull/157)
-* Fixed handling of objs with interleaved materials. [#155](https://github.com/AnalyticalGraphicsInc/obj2gltf/pull/155)
+* Improved parsing models with concave or n-sided faces. [#157](https://github.com/CesiumGS/obj2gltf/pull/157)
+* Fixed handling of objs with interleaved materials. [#155](https://github.com/CesiumGS/obj2gltf/pull/155)
 
 ### 2.3.0 2018-09-19
 
-* Fixed handling of objs with mismatching attribute layouts. [#153](https://github.com/AnalyticalGraphicsInc/obj2gltf/pull/153)
-* Fixed normalization of Windows paths when running the converter on Linux. [#150](https://github.com/AnalyticalGraphicsInc/obj2gltf/pull/150)
-* Added ability to use the first material in the mtl file when the obj is missing `usemtl`. [#133](https://github.com/AnalyticalGraphicsInc/obj2gltf/pull/133)
-* Fixed handling of unnormalized input normals. [#136](https://github.com/AnalyticalGraphicsInc/obj2gltf/pull/136)
+* Fixed handling of objs with mismatching attribute layouts. [#153](https://github.com/CesiumGS/obj2gltf/pull/153)
+* Fixed normalization of Windows paths when running the converter on Linux. [#150](https://github.com/CesiumGS/obj2gltf/pull/150)
+* Added ability to use the first material in the mtl file when the obj is missing `usemtl`. [#133](https://github.com/CesiumGS/obj2gltf/pull/133)
+* Fixed handling of unnormalized input normals. [#136](https://github.com/CesiumGS/obj2gltf/pull/136)
 
 ### 2.2.0 2018-01-29
 
-* Fixed handling of materials where the diffuse and ambient texture are the same. [#127](https://github.com/AnalyticalGraphicsInc/obj2gltf/pull/127)
-* Added ability to load alpha textures. [#124](https://github.com/AnalyticalGraphicsInc/obj2gltf/pull/124)
-* Fixed handling of `usemtl` when appearing before an `o` or `g` token. [#123](https://github.com/AnalyticalGraphicsInc/obj2gltf/pull/123)
-* Fixed output name when running from the command line. [#126](https://github.com/AnalyticalGraphicsInc/obj2gltf/pull/126)
+* Fixed handling of materials where the diffuse and ambient texture are the same. [#127](https://github.com/CesiumGS/obj2gltf/pull/127)
+* Added ability to load alpha textures. [#124](https://github.com/CesiumGS/obj2gltf/pull/124)
+* Fixed handling of `usemtl` when appearing before an `o` or `g` token. [#123](https://github.com/CesiumGS/obj2gltf/pull/123)
+* Fixed output name when running from the command line. [#126](https://github.com/CesiumGS/obj2gltf/pull/126)
 
 ### 2.1.0 2017-12-28
 
-* Fixed loading faces that contain less than 3 vertices. [#120](https://github.com/AnalyticalGraphicsInc/obj2gltf/pull/120)
-* Attempt to load missing materials and textures from within the same directory as the obj. [#117](https://github.com/AnalyticalGraphicsInc/obj2gltf/pull/117)
-* Fixed loading mtllib paths that contain spaces. [#116](https://github.com/AnalyticalGraphicsInc/obj2gltf/pull/116)
-* Fixed checking for transparency when the diffuse texture is used in another texture slot. [#115](https://github.com/AnalyticalGraphicsInc/obj2gltf/pull/115)
-* Fixed parsing mtl textures that contain texture map options. [#109](https://github.com/AnalyticalGraphicsInc/obj2gltf/pull/109)
-* Added back support for the `CONSTANT` technique when a model uses the `KHR_materials_common` extension and has no normals. [#108](https://github.com/AnalyticalGraphicsInc/obj2gltf/pull/108)
-* Improved handling of materials with alpha. If the alpha value is 0.0 it is now treated as 1.0. [#107](https://github.com/AnalyticalGraphicsInc/obj2gltf/pull/107)
+* Fixed loading faces that contain less than 3 vertices. [#120](https://github.com/CesiumGS/obj2gltf/pull/120)
+* Attempt to load missing materials and textures from within the same directory as the obj. [#117](https://github.com/CesiumGS/obj2gltf/pull/117)
+* Fixed loading mtllib paths that contain spaces. [#116](https://github.com/CesiumGS/obj2gltf/pull/116)
+* Fixed checking for transparency when the diffuse texture is used in another texture slot. [#115](https://github.com/CesiumGS/obj2gltf/pull/115)
+* Fixed parsing mtl textures that contain texture map options. [#109](https://github.com/CesiumGS/obj2gltf/pull/109)
+* Added back support for the `CONSTANT` technique when a model uses the `KHR_materials_common` extension and has no normals. [#108](https://github.com/CesiumGS/obj2gltf/pull/108)
+* Improved handling of materials with alpha. If the alpha value is 0.0 it is now treated as 1.0. [#107](https://github.com/CesiumGS/obj2gltf/pull/107)
 
 ### 2.0.0 2017-08-11
 
@@ -74,13 +74,13 @@ Change Log
 
 ### 1.3.0 2017-08-11
 
-* Fixed parsing models with concave or n-sided faces. [#85](https://github.com/AnalyticalGraphicsInc/obj2gltf/pull/85)
-* Fixed parsing models with line breaks. [#85](https://github.com/AnalyticalGraphicsInc/obj2gltf/pull/85)
+* Fixed parsing models with concave or n-sided faces. [#85](https://github.com/CesiumGS/obj2gltf/pull/85)
+* Fixed parsing models with line breaks. [#85](https://github.com/CesiumGS/obj2gltf/pull/85)
 
 ### 1.2.0 2017-07-11
 
-* Change texture sampling to use `NEAREST_MIPMAP_LINEAR` by default. [#83](https://github.com/AnalyticalGraphicsInc/obj2gltf/pull/83).
-* Fixed lighting when generating normals. [#89](https://github.com/AnalyticalGraphicsInc/obj2gltf/pull/89)
+* Change texture sampling to use `NEAREST_MIPMAP_LINEAR` by default. [#83](https://github.com/CesiumGS/obj2gltf/pull/83).
+* Fixed lighting when generating normals. [#89](https://github.com/CesiumGS/obj2gltf/pull/89)
 
 ### 1.1.1 2017-04-25
 
@@ -88,16 +88,16 @@ Change Log
 
 ### 1.1.0 2017-04-25
 
-* Added ability to convert the up-axis of the obj model. [#68](https://github.com/AnalyticalGraphicsInc/obj2gltf/pull/68)
-* Fixed issues with an extra .bin file being saved when using `--separate`. [#62](https://github.com/AnalyticalGraphicsInc/obj2gltf/pull/62)
-* Fixed issue where an ambient color of `[1, 1, 1]` overly brightens the converted model. [#70](https://github.com/AnalyticalGraphicsInc/obj2gltf/pull/70)
+* Added ability to convert the up-axis of the obj model. [#68](https://github.com/CesiumGS/obj2gltf/pull/68)
+* Fixed issues with an extra .bin file being saved when using `--separate`. [#62](https://github.com/CesiumGS/obj2gltf/pull/62)
+* Fixed issue where an ambient color of `[1, 1, 1]` overly brightens the converted model. [#70](https://github.com/CesiumGS/obj2gltf/pull/70)
 
 ### 1.0.0 2017-04-13
 
 * Breaking changes
     * To use `obj2gltf` as a library, call `require('obj2gltf')(input, output, options)`. The previous calling code was `require('obj2gltf').convert(input, output, options)`.
     * Many library options and command-line parameters have been renamed.
-* Project cleanup. [#49](https://github.com/AnalyticalGraphicsInc/obj2gltf/pull/49)
+* Project cleanup. [#49](https://github.com/CesiumGS/obj2gltf/pull/49)
     * Speed improvements, especially for larger models.
     * Preserves the objects and groups in the obj.
     * Added documentation and tests.
@@ -126,8 +126,8 @@ Change Log
 
 ### 0.1.2 - 2016-07-25
 
-* Converted the API to now use promises instead of callbacks. [#21](https://github.com/AnalyticalGraphicsInc/OBJ2GLTF/pull/21)
-* Added the ability to optimize the converted glTF for Cesium by using the sun as a default light source.
+* Converted the API to now use promises instead of callbacks. [#21](https://github.com/CesiumGS/OBJ2GLTF/pull/21)
+* Added the ability to optimize the converted glTF for CesiumJS by using the sun as a default light source.
 
 ### 0.1.1 - 2016-07-21
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright 2016-2017 Analytical Graphics, Inc. and Contributors
+Copyright 2016-2020 Cesium GS, Inc. and Contributors
 
                                  Apache License
                            Version 2.0, January 2004
@@ -188,7 +188,7 @@ Copyright 2016-2017 Analytical Graphics, Inc. and Contributors
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2016-2017 Analytical Graphics, Inc. and Contributors
+   Copyright 2016-2020 Cesium GS, Inc. and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -232,11 +232,11 @@ obj2gltf includes the following third-party code.
 > OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 > THE SOFTWARE.
 
-### Cesium
+### CesiumJS
 
-http://cesiumjs.org/
+https://github.com/CesiumGS/cesium
 
-> Copyright 2011-2016 Cesium Contributors
+> Copyright 2011-2020 CesiumJS Contributors
 >
 > Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 >
@@ -244,7 +244,7 @@ http://cesiumjs.org/
 >
 > Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-See https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
+See https://github.com/CesiumGS/cesium/blob/master/LICENSE.md
 
 ### fs-extra
 
@@ -270,7 +270,7 @@ https://www.npmjs.com/package/fs-extra
 
 https://www.npmjs.com/package/gltf-pipeline
 
-> Copyright 2015-2016 Richard Lee, Analytical Graphics, Inc., and Contributors
+> Copyright 2015-2020 Richard Lee, Cesium GS, Inc., and Contributors
 >
 > Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 >

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OBJ2GLTF
 
-[![Greenkeeper badge](https://badges.greenkeeper.io/AnalyticalGraphicsInc/obj2gltf.svg)](https://greenkeeper.io/)
+[![Greenkeeper badge](https://badges.greenkeeper.io/CesiumGS/obj2gltf.svg)](https://greenkeeper.io/)
 
 Convert OBJ assets to [glTF](https://www.khronos.org/gltf) 2.0.
 
@@ -151,11 +151,11 @@ The documentation will be placed in the `doc` folder.
 
 ## Contributions
 
-Pull requests are appreciated.  Please use the same [Contributor License Agreement (CLA)](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/CONTRIBUTING.md) used for [Cesium](http://cesiumjs.org/).
+Pull requests are appreciated.  Please use the same [Contributor License Agreement (CLA)](https://github.com/CesiumGS/cesium/blob/master/CONTRIBUTING.md) used for [CesiumJS](https://github.com/CesiumGS/cesium).
 
 ---
 
 Developed by the Cesium team.
 <p align="center">
-<a href="http://cesiumjs.org/"><img src="doc/cesium.png" onerror="this.src='cesium.png'"/></a>
+<a href="https://cesium.com/"><img src="doc/cesium.png" onerror="this.src='cesium.png'"/></a>
 </p>

--- a/package.json
+++ b/package.json
@@ -5,21 +5,21 @@
   "license": "Apache-2.0",
   "contributors": [
     {
-      "name": "Analytical Graphics, Inc. and Contributors",
-      "url": "https://github.com/AnalyticalGraphicsInc/obj2gltf/graphs/contributors"
+      "name": "Cesium GS, Inc. and Contributors",
+      "url": "https://github.com/CesiumGS/obj2gltf/graphs/contributors"
     }
   ],
   "keywords": [
     "obj",
     "gltf"
   ],
-  "homepage": "https://github.com/AnalyticalGraphicsInc/obj2gltf",
+  "homepage": "https://github.com/CesiumGS/obj2gltf",
   "repository": {
     "type": "git",
-    "url": "git@github.com:AnalyticalGraphicsInc/obj2gltf.git"
+    "url": "git@github.com:CesiumGS/obj2gltf.git"
   },
   "bugs": {
-    "url": "https://github.com/AnalyticalGraphicsInc/obj2gltf/issues"
+    "url": "https://github.com/CesiumGS/obj2gltf/issues"
   },
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
Part of the CesiumGS github migration.
See https://groups.google.com/forum/?hl=en#!topic/cesium-dev/5sFSChDEtCg

Note: links to https://github.com/CesiumGS/cesium will only work once cesium is transferred over.