### PR TITLE
Remove minFilter and magFilter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+### 3.?.? - 2021-??-??
+
+* Removed `minFilter` and `magFilter` from generated samplers so that runtime engines can use their preferred texture filtering. [#240](https://github.com/CesiumGS/obj2gltf/pull/240)
+
 ### 3.1.1 - 2021-06-22
 
 * Fixed security warnings by updating outdated npm dependencies. [#254](https://github.com/CesiumGS/obj2gltf/pull/254)

--- a/lib/createGltf.js
+++ b/lib/createGltf.js
@@ -89,8 +89,6 @@ function createGltf(objData, options) {
 
     if (gltf.images.length > 0) {
         gltf.samplers.push({
-            magFilter : WebGLConstants.LINEAR,
-            minFilter : WebGLConstants.NEAREST_MIPMAP_LINEAR,
             wrapS : WebGLConstants.REPEAT,
             wrapT : WebGLConstants.REPEAT
         });


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/obj2gltf/issues/239

This lets the runtime engine use the filtering modes they prefer. From the glTF spec:

> Default Filtering Implementation Note: When filtering options are defined, runtime must use them. Otherwise, it is free to adapt filtering to performance or quality goals.