### PR TITLE
Adds texture overrides for independent materials

### DIFF
--- a/bin/obj2gltf.js
+++ b/bin/obj2gltf.js
@@ -134,6 +134,10 @@ const argv = yargs
             choices: ['X', 'Y', 'Z'],
             type: 'string',
             default: 'Y'
+        },
+        materialOverrides : {
+          describe: 'A JSON string describing overriden textures for materials in the .mtl file. Allows specifying different overrides for each material in the .mtl file. Example: \'{\"material1Name\": \"diffuseTexture\": \"PATH_TO_TEXTURE\", \"alphaTexture\": \"PATH_TO_TEXTURE\"}, "material2Name": {...}}\'',
+            type: 'string'
         }
     }).parse(args);
 
@@ -181,7 +185,8 @@ const options = {
     overridingTextures : overridingTextures,
     outputDirectory : outputDirectory,
     inputUpAxis : argv.inputUpAxis,
-    outputUpAxis : argv.outputUpAxis
+    outputUpAxis : argv.outputUpAxis,
+    materialOverrides: JSON.parse(argv.materialOverrides || '{}')
 };
 
 console.time('Total');

--- a/lib/loadMtl.js
+++ b/lib/loadMtl.js
@@ -68,16 +68,17 @@ function loadMtl(mtlPath, options) {
     };
 
     function createMaterial(name) {
+        var materialOverrides = options.materialOverrides[name] || {};
         material = new Material();
         material.name = name;
         material.specularShininess = options.metallicRoughness ? 1.0 : 0.0;
-        material.specularTexture = overridingSpecularTexture;
-        material.specularShininessTexture = overridingSpecularShininessTexture;
-        material.diffuseTexture = overridingDiffuseTexture;
-        material.ambientTexture = overridingAmbientTexture;
-        material.normalTexture = overridingNormalTexture;
-        material.emissiveTexture = overridingEmissiveTexture;
-        material.alphaTexture = overridingAlphaTexture;
+        material.specularTexture = materialOverrides.specularTexture || overridingSpecularTexture;
+        material.specularShininessTexture = materialOverrides.specularShininessTexture || overridingSpecularShininessTexture;
+        material.diffuseTexture = materialOverrides.diffuseTexture || overridingDiffuseTexture;
+        material.ambientTexture = materialOverrides.ambientTexture || overridingAmbientTexture;
+        material.normalTexture = materialOverrides.normalTexture || overridingNormalTexture;
+        material.emissiveTexture = materialOverrides.emissiveTexture || overridingEmissiveTexture;
+        material.alphaTexture = materialOverrides.alphaTexture || overridingAlphaTexture;
         materials.push(material);
     }
 
@@ -139,31 +140,31 @@ function loadMtl(mtlPath, options) {
             value = line.substring(3).trim();
             material.alpha = correctAlpha(1.0 - parseFloat(value));
         } else if (/^map_Ka /i.test(line)) {
-            if (!defined(overridingAmbientTexture)) {
+            if (!defined(material.ambientTexture)) {
                 material.ambientTexture = normalizeTexturePath(line.substring(7).trim(), mtlDirectory);
             }
         } else if (/^map_Ke /i.test(line)) {
-            if (!defined(overridingEmissiveTexture)) {
+            if (!defined(material.emissiveTexture)) {
                 material.emissiveTexture = normalizeTexturePath(line.substring(7).trim(), mtlDirectory);
             }
         } else if (/^map_Kd /i.test(line)) {
-            if (!defined(overridingDiffuseTexture)) {
+            if (!defined(material.diffuseTexture)) {
                 material.diffuseTexture = normalizeTexturePath(line.substring(7).trim(), mtlDirectory);
             }
         } else if (/^map_Ks /i.test(line)) {
-            if (!defined(overridingSpecularTexture)) {
+            if (!defined(material.specularTexture)) {
                 material.specularTexture = normalizeTexturePath(line.substring(7).trim(), mtlDirectory);
             }
         } else if (/^map_Ns /i.test(line)) {
-            if (!defined(overridingSpecularShininessTexture)) {
+            if (!defined(material.specularShininessTexture)) {
                 material.specularShininessTexture = normalizeTexturePath(line.substring(7).trim(), mtlDirectory);
             }
         } else if (/^map_Bump /i.test(line)) {
-            if (!defined(overridingNormalTexture)) {
+            if (!defined(material.normalTexture)) {
                 material.normalTexture = normalizeTexturePath(line.substring(9).trim(), mtlDirectory);
             }
         } else if (/^map_d /i.test(line)) {
-            if (!defined(overridingAlphaTexture)) {
+            if (!defined(material.alphaTexture)) {
                 material.alphaTexture = normalizeTexturePath(line.substring(6).trim(), mtlDirectory);
             }
         }


### PR DESCRIPTION
Allows passing a `materialOverrides` option to the `loadMtl` function.
When generating a new material parsed from the `.mtl` file the overrides
that are specific to this material are applied first before the global
material overrides already existing in the code. This allows the users
to specify different set of materials to override for a model. Following
is an example value for the `materialOverrides` key:

```
{
  "material1Name": {
    "alphaTexture": "path_to_the_texture_file",
    "ambientTexture": "path_to_the_texture_file",
    "diffuseTexture": "path_to_the_texture_file",
    "emissiveTexture": "path_to_the_texture_file",
    "normalTexture": "path_to_the_texture_file",
    "specularTexture": "path_to_the_texture_file",
    "specularShininessTexture": "path_to_the_texture_file",
  }
}
```

It's possible to define more than one material override. If the `.mtl`
file has materials that were not provided in the `materialOverrides`
option they are loaded from the `.mtl` file without any overrides.