### PR TITLE
Update npm dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "10"
+  - "12"
 script:
   - npm run eslint
   - npm run test -- --failTaskOnError --suppressPassed

--- a/bin/obj2gltf.js
+++ b/bin/obj2gltf.js
@@ -25,6 +25,9 @@ const argv = yargs
             type : 'string',
             demandOption : true,
             coerce : function (p) {
+                if (!defined(p)) {
+                    return undefined;
+                }
                 if (p.length === 0) {
                     throw new Error('Input path must be a file name');
                 }
@@ -36,6 +39,9 @@ const argv = yargs
             describe : 'Path of the converted glTF or glb file.',
             type : 'string',
             coerce : function (p) {
+                if (!defined(p)) {
+                    return undefined;
+                }
                 if (p.length === 0) {
                     throw new Error('Output path must be a file name');
                 }

--- a/package.json
+++ b/package.json
@@ -27,24 +27,24 @@
   },
   "dependencies": {
     "bluebird": "^3.7.2",
-    "cesium": "^1.71.0",
-    "fs-extra": "^9.0.1",
-    "jpeg-js": "^0.4.1",
-    "mime": "^2.4.6",
-    "pngjs": "^5.0.0",
-    "yargs": "^15.4.1"
+    "cesium": "^1.83.0",
+    "fs-extra": "^10.0.0",
+    "jpeg-js": "^0.4.3",
+    "mime": "^2.5.2",
+    "pngjs": "^6.0.0",
+    "yargs": "^17.0.1"
   },
   "devDependencies": {
-    "cloc": "^2.5.1",
-    "coveralls": "^3.1.0",
-    "eslint": "^7.5.0",
+    "cloc": "^2.8.0",
+    "coveralls": "^3.1.1",
+    "eslint": "^7.31.0",
     "eslint-config-cesium": "^8.0.1",
     "gulp": "^4.0.2",
-    "jasmine": "^3.6.1",
-    "jasmine-spec-reporter": "^5.0.2",
-    "jsdoc": "^3.6.5",
+    "jasmine": "^3.8.0",
+    "jasmine-spec-reporter": "^7.0.0",
+    "jsdoc": "^3.6.7",
     "nyc": "^15.1.0",
-    "open": "^7.1.0"
+    "open": "^8.2.1"
   },
   "scripts": {
     "jsdoc": "jsdoc ./lib -R ./README.md -d doc",


### PR DESCRIPTION
Updates npm dependencies to their latest versions

* Several libraries now require Node 12
* Only breaking change relevant to `obj2gltf` was `coerce` in yargs: https://github.com/yargs/yargs/blob/master/CHANGELOG.md#1700-2021-05-02