### PR TITLE
Switch to prettier for formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,7 @@ root = true
 
 [*]
 indent_style = space
-indent_size = 4
+indent_size = 2
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-    "extends": "cesium/node",
+    "extends": ["cesium/node", "prettier"],
     "rules": {
         "no-unused-vars": ["error", {"args": "none"}]
     }

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ package-lock.json
 .idea/workspace.xml
 .idea/tasks.xml
 
+# VSCode user-specific
+*.vscode
+
 # Generate data
 .eslintcache
 coverage

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
+/.vscode
 /.idea
 /coverage
 /doc/*
@@ -10,6 +11,7 @@
 .gitattributes
 .nyc_output
 .npmignore
+.prettierignore
 .travis.yml
 gulpfile.js
 *.tgz

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,12 @@
+
+# Ignore everything
+*
+
+# Unignore directories (to all depths) and unignore code and style files in these directories
+!bin/**/
+!doc/**/
+!lib/**/
+!specs/**/
+
+!**/*.js
+!**/*.md

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ node_js:
   - "12"
 script:
   - npm run eslint
-  - npm run prettier-check
   - npm run test -- --failTaskOnError --suppressPassed
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
   - "12"
 script:
   - npm run eslint
+  - npm run prettier-check
   - npm run test -- --failTaskOnError --suppressPassed
 
 after_success:

--- a/package.json
+++ b/package.json
@@ -50,11 +50,6 @@
     "prettier": "2.3.2",
     "pretty-quick": "^3.1.1"
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "eslint && pretty-quick --staged"
-    }
-  },
   "scripts": {
     "jsdoc": "jsdoc ./lib -R ./README.md -d doc",
     "eslint": "eslint \"./**/*.js\" --cache --quiet",

--- a/package.json
+++ b/package.json
@@ -37,14 +37,23 @@
   "devDependencies": {
     "cloc": "^2.8.0",
     "coveralls": "^3.1.1",
-    "eslint": "^7.31.0",
+    "eslint": "^7.32.0",
     "eslint-config-cesium": "^8.0.1",
+    "eslint-config-prettier": "^8.3.0",
     "gulp": "^4.0.2",
+    "husky": "^4.3.8",
     "jasmine": "^3.8.0",
     "jasmine-spec-reporter": "^7.0.0",
     "jsdoc": "^3.6.7",
     "nyc": "^15.1.0",
-    "open": "^8.2.1"
+    "open": "^8.2.1",
+    "prettier": "2.3.2",
+    "pretty-quick": "^3.1.1"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "eslint && pretty-quick --staged"
+    }
   },
   "scripts": {
     "jsdoc": "jsdoc ./lib -R ./README.md -d doc",
@@ -53,7 +62,10 @@
     "test-watch": "gulp test-watch",
     "coverage": "gulp coverage",
     "coveralls": "cat ./coverage/lcov.info | ./node_modules/.bin/coveralls",
-    "cloc": "gulp cloc"
+    "cloc": "gulp cloc",
+    "prettier": "prettier --write \"**/*\"",
+    "prettier-check": "prettier --check \"**/*\"",
+    "pretty-quick": "pretty-quick"
   },
   "bin": {
     "obj2gltf": "./bin/obj2gltf.js"


### PR DESCRIPTION
- Follows the same conventions as CesiumJS.
- Doesn't actually run the formatter or install the pre-commit hook yet.
- The changes can be viewed here: https://github.com/CesiumGS/obj2gltf/compare/prettier-test?expand=1

Steps for migrating to prettier will be as follows:
  1. Merge this into master
  1. Add a `pre-prettier` tag
  1. Actually run prettier and commit the code changes to master
  1. Add a `post-prettier` tag
  1. Open a follow-up PR to add the pre-commit hooks for running prettier

Recommendations for how to update your branches can be found here: https://community.cesium.com/t/cesiumjs-source-code-is-now-formatted-with-prettier/9362