### PR TITLE
Fix unhandled error when mtl is missing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### 3.1.3 - 2021-09-15
+
+- Fixed bug where missing .mtl files were no longer being handled gracefully in Node 16. [#268](https://github.com/CesiumGS/obj2gltf/pull/268)
+
 ### 3.1.2 - 2021-08-02
 
 - Removed `minFilter` and `magFilter` from generated samplers so that runtime engines can use their preferred texture filtering. [#240](https://github.com/CesiumGS/obj2gltf/pull/240)

--- a/lib/readLines.js
+++ b/lib/readLines.js
@@ -2,6 +2,7 @@
 const fsExtra = require("fs-extra");
 const Promise = require("bluebird");
 const readline = require("readline");
+const events = require("events");
 
 module.exports = readLines;
 
@@ -15,23 +16,25 @@ module.exports = readLines;
  * @private
  */
 function readLines(path, callback) {
-  return new Promise(function (resolve, reject) {
-    const stream = fsExtra.createReadStream(path);
-    stream.on("error", reject);
-    stream.on("end", resolve);
+  const stream = fsExtra.createReadStream(path);
+  return events.once(stream, "open").then(function () {
+    return new Promise(function (resolve, reject) {
+      stream.on("error", reject);
+      stream.on("end", resolve);
 
-    const lineReader = readline.createInterface({
-      input: stream,
+      const lineReader = readline.createInterface({
+        input: stream,
+      });
+
+      const callbackWrapper = function (line) {
+        try {
+          callback(line);
+        } catch (error) {
+          reject(error);
+        }
+      };
+
+      lineReader.on("line", callbackWrapper);
     });
-
-    const callbackWrapper = function (line) {
-      try {
-        callback(line);
-      } catch (error) {
-        reject(error);
-      }
-    };
-
-    lineReader.on("line", callbackWrapper);
   });
 }


### PR DESCRIPTION
While testing out Node 16.9.0 for https://github.com/CesiumGS/obj2gltf/issues/266 I noticed that missing mtl files were not being handled gracefully anymore. Both unit tests and command line conversions were failing.

```sh
slilley@Lithium:~/Code/obj2gltf$ node bin/obj2gltf.js -i ./specs/data/box-missing-mtllib/box-missing-mtllib.obj -o ~/Desktop/test.gltf
node:events:371
      throw er; // Unhandled 'error' event
      ^

Error: ENOENT: no such file or directory, open '/box.mtl'
Emitted 'error' event on Interface instance at:
    at ReadStream.onerror (node:readline:265:10)
    at ReadStream.emit (node:events:406:35)
    at emitErrorNT (node:internal/streams/destroy:157:8)
    at emitErrorCloseNT (node:internal/streams/destroy:122:3)
    at processTicksAndRejections (node:internal/process/task_queues:83:21) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: '/box.mtl'
}
```

Previously in Node 14.17.1 I would see

```sh
slilley@Lithium:~/Code/obj2gltf$ node bin/obj2gltf.js -i ./specs/data/box-missing-mtllib/box-missing-mtllib.obj -o ~/Desktop/test.gltf
ENOENT: no such file or directory, open '/box.mtl'
Could not read material file at /box.mtl. Attempting to read the material file from within the obj directory instead.
ENOENT: no such file or directory, open '/home/slilley/Code/obj2gltf/specs/data/box-missing-mtllib/box.mtl'
Could not read material file at /home/slilley/Code/obj2gltf/specs/data/box-missing-mtllib/box.mtl. Using default material instead.
Total: 12.839ms
```

Which would produce a glTF file with a default material.

The bug ended up being similar to the one here: https://stackoverflow.com/questions/62885667/why-does-this-readline-async-iterator-not-work-properly/62887022#62887022. The suggested fix was to wait for the stream to open before initializing `readline`. This seemed to do the trick.