### PR TITLE
Upgrade packages and run Node 16 on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "12"
+  - "16"
 script:
   - npm run eslint
   - npm run prettier-check

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### 3.1.4 - 2021-10-15
+
+- Unlocked CesiumJS package now that CesiumJS 1.86.1 is released with a fix for Node 16. [#270](https://github.com/CesiumGS/obj2gltf/pull/270)
+
 ### 3.1.3 - 2021-09-15
 
 - Fixed bug where missing .mtl files were no longer being handled gracefully in Node 16. [#268](https://github.com/CesiumGS/obj2gltf/pull/268)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obj2gltf",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "Convert OBJ model format to glTF",
   "license": "Apache-2.0",
   "contributors": [
@@ -27,26 +27,26 @@
   },
   "dependencies": {
     "bluebird": "^3.7.2",
-    "cesium": "1.84.0",
+    "cesium": "^1.86.1",
     "fs-extra": "^10.0.0",
     "jpeg-js": "^0.4.3",
     "mime": "^2.5.2",
     "pngjs": "^6.0.0",
-    "yargs": "^17.0.1"
+    "yargs": "^17.2.1"
   },
   "devDependencies": {
     "cloc": "^2.8.0",
     "coveralls": "^3.1.1",
-    "eslint": "^7.32.0",
+    "eslint": "^8.0.1",
     "eslint-config-cesium": "^8.0.1",
     "eslint-config-prettier": "^8.3.0",
     "gulp": "^4.0.2",
     "husky": "^4.3.8",
-    "jasmine": "^3.8.0",
+    "jasmine": "^3.10.0",
     "jasmine-spec-reporter": "^7.0.0",
     "jsdoc": "^3.6.7",
     "nyc": "^15.1.0",
-    "open": "^8.2.1",
+    "open": "^8.3.0",
     "prettier": "2.3.2",
     "pretty-quick": "^3.1.1"
   },


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/obj2gltf/issues/269 now that the CesiumJS 1.86.1 is released.

Also took this opportunity to use Node 16 for CI since it will be active LTS soon.