### PR TITLE
Add ThirdParty.json

### DIFF
--- a/ThirdParty.json
+++ b/ThirdParty.json
@@ -1,0 +1,58 @@
+[
+  {
+    "name": "bluebird",
+    "license": [
+      "MIT"
+    ],
+    "version": "3.7.2",
+    "url": "https://www.npmjs.com/package/bluebird"
+  },
+  {
+    "name": "cesium",
+    "license": [
+      "Apache-2.0"
+    ],
+    "version": "1.93.0",
+    "url": "https://www.npmjs.com/package/cesium"
+  },
+  {
+    "name": "fs-extra",
+    "license": [
+      "MIT"
+    ],
+    "version": "10.1.0",
+    "url": "https://www.npmjs.com/package/fs-extra"
+  },
+  {
+    "name": "jpeg-js",
+    "license": [
+      "BSD-3-Clause"
+    ],
+    "version": "0.4.3",
+    "url": "https://www.npmjs.com/package/jpeg-js"
+  },
+  {
+    "name": "mime",
+    "license": [
+      "MIT"
+    ],
+    "version": "2.6.0",
+    "url": "https://www.npmjs.com/package/mime"
+  },
+  {
+    "name": "pngjs",
+    "license": [
+      "MIT"
+    ],
+    "version": "6.0.0",
+    "url": "https://www.npmjs.com/package/pngjs"
+  },
+  {
+    "name": "yargs",
+    "license": [
+      "MIT"
+    ],
+    "version": "17.4.1",
+    "url": "https://www.npmjs.com/package/yargs"
+  }
+]

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,6 +11,7 @@ const open = require("open");
 const path = require("path");
 const yargs = require("yargs");
 
+const defaultValue = Cesium.defaultValue;
 const defined = Cesium.defined;
 const argv = yargs.argv;
 
@@ -33,6 +34,7 @@ module.exports = {
   "test-watch": testWatch,
   coverage: coverage,
   cloc: cloc,
+  "generate-third-party": generateThirdParty,
 };
 
 function test(done) {
@@ -116,4 +118,88 @@ function cloc() {
       });
     });
   });
+}
+
+function getLicenseDataFromPackage(packageName, override) {
+  override = defaultValue(override, defaultValue.EMPTY_OBJECT);
+  const packagePath = path.join("node_modules", packageName, "package.json");
+
+  if (!fsExtra.existsSync(packagePath)) {
+    throw new Error(`Unable to find ${packageName} license information`);
+  }
+
+  const contents = fsExtra.readFileSync(packagePath);
+  const packageJson = JSON.parse(contents);
+
+  let licenseField = override.license;
+
+  if (!licenseField) {
+    licenseField = [packageJson.license];
+  }
+
+  if (!licenseField && packageJson.licenses) {
+    licenseField = packageJson.licenses;
+  }
+
+  if (!licenseField) {
+    console.log(`No license found for ${packageName}`);
+    licenseField = ["NONE"];
+  }
+
+  let version = packageJson.version;
+  if (!packageJson.version) {
+    console.log(`No version information found for ${packageName}`);
+    version = "NONE";
+  }
+
+  return {
+    name: packageName,
+    license: licenseField,
+    version: version,
+    url: `https://www.npmjs.com/package/${packageName}`,
+    notes: override.notes,
+  };
+}
+
+function readThirdPartyExtraJson() {
+  const path = "ThirdParty.extra.json";
+  if (fsExtra.existsSync(path)) {
+    const contents = fsExtra.readFileSync(path);
+    return JSON.parse(contents);
+  }
+  return [];
+}
+
+async function generateThirdParty() {
+  const packageJson = JSON.parse(fsExtra.readFileSync("package.json"));
+  const thirdPartyExtraJson = readThirdPartyExtraJson();
+
+  const thirdPartyJson = [];
+
+  const dependencies = packageJson.dependencies;
+  for (const packageName in dependencies) {
+    if (dependencies.hasOwnProperty(packageName)) {
+      const override = thirdPartyExtraJson.find(
+        (entry) => entry.name === packageName
+      );
+      thirdPartyJson.push(getLicenseDataFromPackage(packageName, override));
+    }
+  }
+
+  thirdPartyJson.sort(function (a, b) {
+    const nameA = a.name.toLowerCase();
+    const nameB = b.name.toLowerCase();
+    if (nameA < nameB) {
+      return -1;
+    }
+    if (nameA > nameB) {
+      return 1;
+    }
+    return 0;
+  });
+
+  fsExtra.writeFileSync(
+    "ThirdParty.json",
+    JSON.stringify(thirdPartyJson, null, 2)
+  );
 }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
     "cloc": "gulp cloc",
     "prettier": "prettier --write \"**/*\"",
     "prettier-check": "prettier --check \"**/*\"",
-    "pretty-quick": "pretty-quick"
+    "pretty-quick": "pretty-quick",
+    "generate-third-party": "gulp generate-third-party"
   },
   "bin": {
     "obj2gltf": "./bin/obj2gltf.js"


### PR DESCRIPTION
Adds `ThirdParty.json` for tracking third party dependencies. To regenerate the file run `npm run generate-third-party`.

CC @shehzan10 