### PR TITLE
Don't merge buffers if final buffer exceeds fs.write maximum of `2147479552` bytes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### 3.1.5 - ????-??-??
+
+- Fixed crash when writing GLB files above 2GB. [#280](https://github.com/CesiumGS/obj2gltf/pull/280)
+
 ### 3.1.4 - 2021-10-15
 
 - Unlocked CesiumJS package now that CesiumJS 1.86.1 is released with a fix for Node 16. [#270](https://github.com/CesiumGS/obj2gltf/pull/270)

--- a/lib/createGltf.js
+++ b/lib/createGltf.js
@@ -1,5 +1,7 @@
 "use strict";
-const BUFFER_MAX_BYTE_LENGTH = require("buffer").constants.MAX_LENGTH;
+const FS_WRITE_MAX_LENGTH = 2147479552; // See https://github.com/nodejs/node/issues/35605
+const BUFFER_MAX_LENGTH = require("buffer").constants.MAX_LENGTH;
+const BUFFER_MAX_BYTE_LENGTH = Math.min(FS_WRITE_MAX_LENGTH, BUFFER_MAX_LENGTH);
 const Cesium = require("cesium");
 const getBufferPadded = require("./getBufferPadded");
 const getDefaultMaterial = require("./loadMtl").getDefaultMaterial;


### PR DESCRIPTION
We have a couple areas in obj2gltf and gltf-pipeline that prevent merging buffers if the combined buffer would be greater than Node's maximum buffer size. This size was increased to 4,294,967,296 (2^32) bytes a little while back for 64-bit platforms.

The problem is fs.write has a separate maximum of 2,147,479,552 bytes which is the limit of the Linux [`write`](https://man7.org/linux/man-pages/man2/write.2.html) syscall. Node will throw an error if the buffer being written is greater than that value (actually, it checks if the value is a valid Int32 which is a slightly larger value).

So really we need to observe the fs.write limit.

See also: https://github.com/CesiumGS/gltf-pipeline/pull/627