### PR TITLE
Require Node 14

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "main": "index.js",
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "dependencies": {
     "bluebird": "^3.7.2",


### PR DESCRIPTION
obj2gltf depends on CesiumJS which requires Node 14