### PR TITLE
Dependency Updates

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,7 +7,6 @@ const fsExtra = require("fs-extra");
 const gulp = require("gulp");
 const Jasmine = require("jasmine");
 const JasmineSpecReporter = require("jasmine-spec-reporter").SpecReporter;
-const open = require("open");
 const path = require("path");
 const yargs = require("yargs");
 
@@ -81,7 +80,6 @@ async function coverage() {
       stdio: [process.stdin, process.stdout, process.stderr],
     }
   );
-  open("coverage/lcov-report/index.html");
 }
 
 function cloc() {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "fs-extra": "^11.0.0",
     "jpeg-js": "^0.4.3",
     "mime": "^3.0.0",
-    "pngjs": "^6.0.0",
+    "pngjs": "^7.0.0",
     "yargs": "^17.2.1"
   },
   "devDependencies": {
@@ -48,7 +48,7 @@
     "jsdoc": "^4.0.0",
     "nyc": "^15.1.0",
     "open": "^8.3.0",
-    "prettier": "2.8.4",
+    "prettier": "2.8.8",
     "pretty-quick": "^3.1.1"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "jasmine-spec-reporter": "^7.0.0",
     "jsdoc": "^4.0.0",
     "nyc": "^15.1.0",
-    "open": "^8.3.0",
     "prettier": "2.8.8",
     "pretty-quick": "^3.1.1"
   },


### PR DESCRIPTION
Dev dependency updates:
1. Deletes `open` library from the `package.json` and `gulpfile` since it is now an ESM only package and isn't very useful
2. Updates prettier

Dependency updates:
1. `pngjs`: `6.0.0` -> `7.0.0` [See changelog](https://github.com/pngjs/pngjs/blob/main/CHANGELOG.md)