### PR TITLE
Monthly Maintenance

### DIFF
--- a/bin/obj2gltf.js
+++ b/bin/obj2gltf.js
@@ -170,9 +170,10 @@ const argv = yargs
 
 if (argv.metallicRoughness + argv.specularGlossiness > 1) {
   console.error(
-    "Only one material type may be set from [--metallicRoughness, --specularGlossiness]."
+    "Only one material type may be set from [--metallicRoughness, --specularGlossiness].",
   );
-  process.exit(1);
+  process.exitCode = 1;
+  return;
 }
 
 if (
@@ -180,9 +181,10 @@ if (
   defined(argv.specularGlossinessTexture)
 ) {
   console.error(
-    "--metallicRoughnessOcclusionTexture and --specularGlossinessTexture cannot both be set."
+    "--metallicRoughnessOcclusionTexture and --specularGlossinessTexture cannot both be set.",
   );
-  process.exit(1);
+  process.exitCode = 1;
+  return;
 }
 
 const objPath = argv.input;
@@ -242,5 +244,5 @@ obj2gltf(objPath, options)
   })
   .catch(function (error) {
     console.log(error.message);
-    process.exit(1);
+    process.exitCode = 1;
   });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -44,7 +44,7 @@ async function test() {
     new JasmineSpecReporter({
       displaySuccessfulSpec:
         !defined(argv.suppressPassed) || !argv.suppressPassed,
-    })
+    }),
   );
   const results = await jasmine.execute();
   if (argv.failTaskOnError && results.overallStatus === "failed") {
@@ -78,7 +78,7 @@ async function coverage() {
       " JASMINE_CONFIG_PATH=specs/jasmine.json",
     {
       stdio: [process.stdin, process.stdout, process.stderr],
-    }
+    },
   );
 }
 
@@ -178,7 +178,7 @@ async function generateThirdParty() {
   for (const packageName in dependencies) {
     if (dependencies.hasOwnProperty(packageName)) {
       const override = thirdPartyExtraJson.find(
-        (entry) => entry.name === packageName
+        (entry) => entry.name === packageName,
       );
       thirdPartyJson.push(getLicenseDataFromPackage(packageName, override));
     }
@@ -198,6 +198,6 @@ async function generateThirdParty() {
 
   fsExtra.writeFileSync(
     "ThirdParty.json",
-    JSON.stringify(thirdPartyJson, null, 2)
+    JSON.stringify(thirdPartyJson, null, 2),
   );
 }

--- a/lib/ArrayStorage.js
+++ b/lib/ArrayStorage.js
@@ -26,7 +26,7 @@ function ArrayStorage(componentDatatype) {
 function resize(storage, length) {
   const typedArray = ComponentDatatype.createTypedArray(
     storage.componentDatatype,
-    length
+    length,
   );
   typedArray.set(storage.typedArray);
   storage.typedArray = typedArray;

--- a/lib/createGltf.js
+++ b/lib/createGltf.js
@@ -82,7 +82,7 @@ function createGltf(objData, options) {
         bufferState,
         uint32Indices,
         meshes[0],
-        options
+        options,
       );
       addNode(gltf, node.name, meshIndex, undefined);
     } else {
@@ -96,7 +96,7 @@ function createGltf(objData, options) {
           bufferState,
           uint32Indices,
           mesh,
-          options
+          options,
         );
         addNode(gltf, mesh.name, meshIndex, parentIndex);
       }
@@ -158,28 +158,28 @@ function addCombinedBuffers(gltf, bufferState, name) {
     bufferState.positionBuffers,
     bufferState.positionAccessors,
     12,
-    WebGLConstants.ARRAY_BUFFER
+    WebGLConstants.ARRAY_BUFFER,
   );
   addCombinedBufferView(
     gltf,
     bufferState.normalBuffers,
     bufferState.normalAccessors,
     12,
-    WebGLConstants.ARRAY_BUFFER
+    WebGLConstants.ARRAY_BUFFER,
   );
   addCombinedBufferView(
     gltf,
     bufferState.uvBuffers,
     bufferState.uvAccessors,
     8,
-    WebGLConstants.ARRAY_BUFFER
+    WebGLConstants.ARRAY_BUFFER,
   );
   addCombinedBufferView(
     gltf,
     bufferState.indexBuffers,
     bufferState.indexAccessors,
     undefined,
-    WebGLConstants.ELEMENT_ARRAY_BUFFER
+    WebGLConstants.ELEMENT_ARRAY_BUFFER,
   );
 
   let buffers = [];
@@ -187,7 +187,7 @@ function addCombinedBuffers(gltf, bufferState, name) {
     bufferState.positionBuffers,
     bufferState.normalBuffers,
     bufferState.uvBuffers,
-    bufferState.indexBuffers
+    bufferState.indexBuffers,
   );
   const buffer = getBufferPadded(Buffer.concat(buffers));
 
@@ -208,7 +208,7 @@ function addSeparateBufferView(
   accessor,
   byteStride,
   target,
-  name
+  name,
 ) {
   const bufferIndex = gltf.buffers.length;
   const bufferViewIndex = gltf.bufferViews.length;
@@ -241,7 +241,7 @@ function addSeparateBufferViews(
   accessors,
   byteStride,
   target,
-  name
+  name,
 ) {
   const length = buffers.length;
   for (let i = 0; i < length; ++i) {
@@ -251,7 +251,7 @@ function addSeparateBufferViews(
       accessors[i],
       byteStride,
       target,
-      name
+      name,
     );
   }
 }
@@ -263,7 +263,7 @@ function addSeparateBuffers(gltf, bufferState, name) {
     bufferState.positionAccessors,
     12,
     WebGLConstants.ARRAY_BUFFER,
-    name
+    name,
   );
   addSeparateBufferViews(
     gltf,
@@ -271,7 +271,7 @@ function addSeparateBuffers(gltf, bufferState, name) {
     bufferState.normalAccessors,
     12,
     WebGLConstants.ARRAY_BUFFER,
-    name
+    name,
   );
   addSeparateBufferViews(
     gltf,
@@ -279,7 +279,7 @@ function addSeparateBuffers(gltf, bufferState, name) {
     bufferState.uvAccessors,
     8,
     WebGLConstants.ARRAY_BUFFER,
-    name
+    name,
   );
   addSeparateBufferViews(
     gltf,
@@ -287,7 +287,7 @@ function addSeparateBuffers(gltf, bufferState, name) {
     bufferState.indexAccessors,
     undefined,
     WebGLConstants.ELEMENT_ARRAY_BUFFER,
-    name
+    name,
   );
 }
 
@@ -295,7 +295,7 @@ function addBuffers(gltf, bufferState, name, separate) {
   const buffers = bufferState.positionBuffers.concat(
     bufferState.normalBuffers,
     bufferState.uvBuffers,
-    bufferState.indexBuffers
+    bufferState.indexBuffers,
   );
   const buffersLength = buffers.length;
   let buffersByteLength = 0;
@@ -440,7 +440,7 @@ function primitiveInfoMatch(a, b) {
 function getSplitMaterialName(
   originalMaterialName,
   primitiveInfo,
-  primitiveInfoByMaterial
+  primitiveInfoByMaterial,
 ) {
   let splitMaterialName = originalMaterialName;
   let suffix = 2;
@@ -448,7 +448,7 @@ function getSplitMaterialName(
     if (
       primitiveInfoMatch(
         primitiveInfo,
-        primitiveInfoByMaterial[splitMaterialName]
+        primitiveInfoByMaterial[splitMaterialName],
       )
     ) {
       break;
@@ -478,19 +478,19 @@ function splitIncompatibleMaterials(nodes, materials, options) {
         };
         const originalMaterialName = defaultValue(
           primitive.material,
-          "default"
+          "default",
         );
         const splitMaterialName = getSplitMaterialName(
           originalMaterialName,
           primitiveInfo,
-          primitiveInfoByMaterial
+          primitiveInfoByMaterial,
         );
         primitive.material = splitMaterialName;
         primitiveInfoByMaterial[splitMaterialName] = primitiveInfo;
 
         let splitMaterial = getMaterialByName(
           splitMaterials,
-          splitMaterialName
+          splitMaterialName,
         );
         if (defined(splitMaterial)) {
           continue;
@@ -498,7 +498,7 @@ function splitIncompatibleMaterials(nodes, materials, options) {
 
         const originalMaterial = getMaterialByName(
           materials,
-          originalMaterialName
+          originalMaterialName,
         );
         if (defined(originalMaterial)) {
           splitMaterial = cloneMaterial(originalMaterial, !hasUvs);
@@ -581,7 +581,7 @@ function addPrimitive(
   mesh,
   primitive,
   index,
-  options
+  options,
 ) {
   const hasPositions = primitive.positions.length > 0;
   const hasNormals = primitive.normals.length > 0;
@@ -593,7 +593,7 @@ function addPrimitive(
       gltf,
       primitive.positions,
       3,
-      `${mesh.name}_${index}_positions`
+      `${mesh.name}_${index}_positions`,
     );
     attributes.POSITION = accessorIndex;
     bufferState.positionBuffers.push(primitive.positions.toFloatBuffer());
@@ -604,7 +604,7 @@ function addPrimitive(
       gltf,
       primitive.normals,
       3,
-      `${mesh.name}_${index}_normals`
+      `${mesh.name}_${index}_normals`,
     );
     attributes.NORMAL = accessorIndex;
     bufferState.normalBuffers.push(primitive.normals.toFloatBuffer());
@@ -615,7 +615,7 @@ function addPrimitive(
       gltf,
       primitive.uvs,
       2,
-      `${mesh.name}_${index}_texcoords`
+      `${mesh.name}_${index}_texcoords`,
     );
     attributes.TEXCOORD_0 = accessorIndex;
     bufferState.uvBuffers.push(primitive.uvs.toFloatBuffer());
@@ -626,7 +626,7 @@ function addPrimitive(
     gltf,
     primitive.indices,
     uint32Indices,
-    `${mesh.name}_${index}_indices`
+    `${mesh.name}_${index}_indices`,
   );
   const indexBuffer = uint32Indices
     ? primitive.indices.toUint32Buffer()
@@ -644,7 +644,7 @@ function addPrimitive(
     gltf,
     materials,
     primitive.material,
-    options
+    options,
   );
 
   return {
@@ -669,8 +669,8 @@ function addMesh(gltf, materials, bufferState, uint32Indices, mesh, options) {
         mesh,
         primitives[i],
         i,
-        options
-      )
+        options,
+      ),
     );
   }
 

--- a/lib/loadMtl.js
+++ b/lib/loadMtl.js
@@ -43,15 +43,15 @@ function loadMtl(mtlPath, options) {
   const overridingTextures = options.overridingTextures;
   const overridingSpecularTexture = defaultValue(
     overridingTextures.metallicRoughnessOcclusionTexture,
-    overridingTextures.specularGlossinessTexture
+    overridingTextures.specularGlossinessTexture,
   );
   const overridingSpecularShininessTexture = defaultValue(
     overridingTextures.metallicRoughnessOcclusionTexture,
-    overridingTextures.specularGlossinessTexture
+    overridingTextures.specularGlossinessTexture,
   );
   const overridingAmbientTexture = defaultValue(
     overridingTextures.metallicRoughnessOcclusionTexture,
-    overridingTextures.occlusionTexture
+    overridingTextures.occlusionTexture,
   );
   const overridingNormalTexture = overridingTextures.normalTexture;
   const overridingDiffuseTexture = overridingTextures.baseColorTexture;
@@ -76,7 +76,7 @@ function loadMtl(mtlPath, options) {
     ? undefined
     : decodeOptions;
   const specularShinessTextureOptions = defined(
-    overridingSpecularShininessTexture
+    overridingSpecularShininessTexture,
   )
     ? undefined
     : decodeOptions;
@@ -161,49 +161,49 @@ function loadMtl(mtlPath, options) {
       if (!defined(overridingAmbientTexture)) {
         material.ambientTexture = normalizeTexturePath(
           line.substring(7).trim(),
-          mtlDirectory
+          mtlDirectory,
         );
       }
     } else if (/^map_Ke /i.test(line)) {
       if (!defined(overridingEmissiveTexture)) {
         material.emissiveTexture = normalizeTexturePath(
           line.substring(7).trim(),
-          mtlDirectory
+          mtlDirectory,
         );
       }
     } else if (/^map_Kd /i.test(line)) {
       if (!defined(overridingDiffuseTexture)) {
         material.diffuseTexture = normalizeTexturePath(
           line.substring(7).trim(),
-          mtlDirectory
+          mtlDirectory,
         );
       }
     } else if (/^map_Ks /i.test(line)) {
       if (!defined(overridingSpecularTexture)) {
         material.specularTexture = normalizeTexturePath(
           line.substring(7).trim(),
-          mtlDirectory
+          mtlDirectory,
         );
       }
     } else if (/^map_Ns /i.test(line)) {
       if (!defined(overridingSpecularShininessTexture)) {
         material.specularShininessTexture = normalizeTexturePath(
           line.substring(7).trim(),
-          mtlDirectory
+          mtlDirectory,
         );
       }
     } else if (/^map_Bump /i.test(line)) {
       if (!defined(overridingNormalTexture)) {
         material.normalTexture = normalizeTexturePath(
           line.substring(9).trim(),
-          mtlDirectory
+          mtlDirectory,
         );
       }
     } else if (/^map_d /i.test(line)) {
       if (!defined(overridingAlphaTexture)) {
         material.alphaTexture = normalizeTexturePath(
           line.substring(6).trim(),
-          mtlDirectory
+          mtlDirectory,
         );
       }
     }
@@ -269,7 +269,7 @@ function loadMtl(mtlPath, options) {
           mtlDirectory,
           texturePromiseMap,
           texturePromises,
-          options
+          options,
         );
       }
     });
@@ -326,7 +326,7 @@ function loadMaterialTexture(
   mtlDirectory,
   texturePromiseMap,
   texturePromises,
-  options
+  options,
 ) {
   const texturePath = material[name];
   if (!defined(texturePath)) {
@@ -339,30 +339,30 @@ function loadMaterialTexture(
     if (options.secure && outsideDirectory(texturePath, mtlDirectory)) {
       // Try looking for the texture in the same directory as the obj
       options.logger(
-        "Texture file is outside of the mtl directory and the secure flag is true. Attempting to read the texture file from within the obj directory instead."
+        "Texture file is outside of the mtl directory and the secure flag is true. Attempting to read the texture file from within the obj directory instead.",
       );
-      texturePromise = loadTexture(shallowPath, textureOptions).catch(function (
-        error
-      ) {
-        options.logger(error.message);
-        options.logger(
-          `Could not read texture file at ${shallowPath}. This texture will be ignored`
-        );
-      });
+      texturePromise = loadTexture(shallowPath, textureOptions).catch(
+        function (error) {
+          options.logger(error.message);
+          options.logger(
+            `Could not read texture file at ${shallowPath}. This texture will be ignored`,
+          );
+        },
+      );
     } else {
       texturePromise = loadTexture(texturePath, textureOptions)
         .catch(function (error) {
           // Try looking for the texture in the same directory as the obj
           options.logger(error.message);
           options.logger(
-            `Could not read texture file at ${texturePath}. Attempting to read the texture file from within the obj directory instead.`
+            `Could not read texture file at ${texturePath}. Attempting to read the texture file from within the obj directory instead.`,
           );
           return loadTexture(shallowPath, textureOptions);
         })
         .catch(function (error) {
           options.logger(error.message);
           options.logger(
-            `Could not read texture file at ${shallowPath}. This texture will be ignored.`
+            `Could not read texture file at ${shallowPath}. This texture will be ignored.`,
           );
         });
     }
@@ -372,7 +372,7 @@ function loadMaterialTexture(
   texturePromises.push(
     texturePromise.then(function (texture) {
       material[name] = texture;
-    })
+    }),
   );
 }
 
@@ -399,7 +399,7 @@ function resizeChannel(
   sourceHeight,
   targetPixels,
   targetWidth,
-  targetHeight
+  targetHeight,
 ) {
   // Nearest neighbor sampling
   const widthRatio = sourceWidth / targetWidth;
@@ -425,7 +425,7 @@ function getTextureChannel(
   index,
   targetWidth,
   targetHeight,
-  targetChannel
+  targetChannel,
 ) {
   const pixels = texture.pixels; // RGBA
   const sourceWidth = texture.width;
@@ -457,7 +457,7 @@ function getTextureChannel(
       sourceHeight,
       targetChannel,
       targetWidth,
-      targetHeight
+      targetHeight,
     );
   }
 
@@ -487,7 +487,7 @@ function getMinimumDimensions(textures, options) {
     const texture = textures[i];
     if (texture.width !== width || texture.height !== height) {
       options.logger(
-        `Texture ${texture.path} will be scaled from ${texture.width}x${texture.height} to ${width}x${height}.`
+        `Texture ${texture.path} will be scaled from ${texture.width}x${texture.height} to ${width}x${height}.`,
       );
     }
   }
@@ -524,7 +524,7 @@ function createDiffuseAlphaTexture(diffuseTexture, alphaTexture, options) {
 
   if (!defined(diffuseTexture.pixels) || !defined(alphaTexture.pixels)) {
     options.logger(
-      `Could not get decoded texture data for ${diffuseTexture.path} or ${alphaTexture.path}. The material will be created without an alpha texture.`
+      `Could not get decoded texture data for ${diffuseTexture.path} or ${alphaTexture.path}. The material will be created without an alpha texture.`,
     );
     return diffuseTexture;
   }
@@ -543,7 +543,7 @@ function createDiffuseAlphaTexture(diffuseTexture, alphaTexture, options) {
     0,
     width,
     height,
-    scratchChannel
+    scratchChannel,
   );
   writeChannel(pixels, redChannel, 0);
   const greenChannel = getTextureChannel(
@@ -551,7 +551,7 @@ function createDiffuseAlphaTexture(diffuseTexture, alphaTexture, options) {
     1,
     width,
     height,
-    scratchChannel
+    scratchChannel,
   );
   writeChannel(pixels, greenChannel, 1);
   const blueChannel = getTextureChannel(
@@ -559,7 +559,7 @@ function createDiffuseAlphaTexture(diffuseTexture, alphaTexture, options) {
     2,
     width,
     height,
-    scratchChannel
+    scratchChannel,
   );
   writeChannel(pixels, blueChannel, 2);
 
@@ -569,7 +569,7 @@ function createDiffuseAlphaTexture(diffuseTexture, alphaTexture, options) {
     3,
     width,
     height,
-    scratchChannel
+    scratchChannel,
   );
   if (isChannelSingleColor(alphaChannel)) {
     alphaChannel = getTextureChannel(
@@ -577,7 +577,7 @@ function createDiffuseAlphaTexture(diffuseTexture, alphaTexture, options) {
       0,
       width,
       height,
-      scratchChannel
+      scratchChannel,
     );
   }
   writeChannel(pixels, alphaChannel, 3);
@@ -597,7 +597,7 @@ function createMetallicRoughnessTexture(
   metallicTexture,
   roughnessTexture,
   occlusionTexture,
-  options
+  options,
 ) {
   if (defined(options.overridingTextures.metallicRoughnessOcclusionTexture)) {
     return metallicTexture;
@@ -613,21 +613,21 @@ function createMetallicRoughnessTexture(
 
   if (packMetallic && !defined(metallicTexture.pixels)) {
     options.logger(
-      `Could not get decoded texture data for ${metallicTexture.path}. The material will be created without a metallicRoughness texture.`
+      `Could not get decoded texture data for ${metallicTexture.path}. The material will be created without a metallicRoughness texture.`,
     );
     return undefined;
   }
 
   if (packRoughness && !defined(roughnessTexture.pixels)) {
     options.logger(
-      `Could not get decoded texture data for ${roughnessTexture.path}. The material will be created without a metallicRoughness texture.`
+      `Could not get decoded texture data for ${roughnessTexture.path}. The material will be created without a metallicRoughness texture.`,
     );
     return undefined;
   }
 
   if (packOcclusion && !defined(occlusionTexture.pixels)) {
     options.logger(
-      `Could not get decoded texture data for ${occlusionTexture.path}. The occlusion texture will not be packed in the metallicRoughness texture.`
+      `Could not get decoded texture data for ${occlusionTexture.path}. The occlusion texture will not be packed in the metallicRoughness texture.`,
     );
     return undefined;
   }
@@ -654,7 +654,7 @@ function createMetallicRoughnessTexture(
       0,
       width,
       height,
-      scratchChannel
+      scratchChannel,
     );
     writeChannel(pixels, metallicChannel, 2);
   }
@@ -666,7 +666,7 @@ function createMetallicRoughnessTexture(
       0,
       width,
       height,
-      scratchChannel
+      scratchChannel,
     );
     writeChannel(pixels, roughnessChannel, 1);
   }
@@ -678,7 +678,7 @@ function createMetallicRoughnessTexture(
       0,
       width,
       height,
-      scratchChannel
+      scratchChannel,
     );
     writeChannel(pixels, occlusionChannel, 0);
   }
@@ -703,7 +703,7 @@ function createMetallicRoughnessTexture(
 function createSpecularGlossinessTexture(
   specularTexture,
   glossinessTexture,
-  options
+  options,
 ) {
   if (defined(options.overridingTextures.specularGlossinessTexture)) {
     return specularTexture;
@@ -718,23 +718,23 @@ function createSpecularGlossinessTexture(
 
   if (packSpecular && !defined(specularTexture.pixels)) {
     options.logger(
-      `Could not get decoded texture data for ${specularTexture.path}. The material will be created without a specularGlossiness texture.`
+      `Could not get decoded texture data for ${specularTexture.path}. The material will be created without a specularGlossiness texture.`,
     );
     return undefined;
   }
 
   if (packGlossiness && !defined(glossinessTexture.pixels)) {
     options.logger(
-      `Could not get decoded texture data for ${glossinessTexture.path}. The material will be created without a specularGlossiness texture.`
+      `Could not get decoded texture data for ${glossinessTexture.path}. The material will be created without a specularGlossiness texture.`,
     );
     return undefined;
   }
 
-  const packedTextures = [specularTexture, glossinessTexture].filter(function (
-    texture
-  ) {
-    return defined(texture) && defined(texture.pixels);
-  });
+  const packedTextures = [specularTexture, glossinessTexture].filter(
+    function (texture) {
+      return defined(texture) && defined(texture.pixels);
+    },
+  );
 
   const dimensions = getMinimumDimensions(packedTextures, options);
   const width = dimensions[0];
@@ -750,7 +750,7 @@ function createSpecularGlossinessTexture(
       0,
       width,
       height,
-      scratchChannel
+      scratchChannel,
     );
     writeChannel(pixels, redChannel, 0);
     const greenChannel = getTextureChannel(
@@ -758,7 +758,7 @@ function createSpecularGlossinessTexture(
       1,
       width,
       height,
-      scratchChannel
+      scratchChannel,
     );
     writeChannel(pixels, greenChannel, 1);
     const blueChannel = getTextureChannel(
@@ -766,7 +766,7 @@ function createSpecularGlossinessTexture(
       2,
       width,
       height,
-      scratchChannel
+      scratchChannel,
     );
     writeChannel(pixels, blueChannel, 2);
   }
@@ -778,7 +778,7 @@ function createSpecularGlossinessTexture(
       0,
       width,
       height,
-      scratchChannel
+      scratchChannel,
     );
     writeChannel(pixels, glossinessChannel, 3);
   }
@@ -811,12 +811,12 @@ function createSpecularGlossinessMaterial(material, options) {
   const specularGlossinessTexture = createSpecularGlossinessTexture(
     specularTexture,
     glossinessTexture,
-    options
+    options,
   );
   const diffuseAlphaTexture = createDiffuseAlphaTexture(
     diffuseTexture,
     alphaTexture,
-    options
+    options,
   );
 
   let emissiveFactor = material.emissiveColor.slice(0, 3);
@@ -888,12 +888,12 @@ function createMetallicRoughnessMaterial(material, options) {
     metallicTexture,
     roughnessTexture,
     occlusionTexture,
-    options
+    options,
   );
   const diffuseAlphaTexture = createDiffuseAlphaTexture(
     baseColorTexture,
     alphaTexture,
-    options
+    options,
   );
 
   if (options.packOcclusion) {

--- a/lib/loadObj.js
+++ b/lib/loadObj.js
@@ -65,7 +65,7 @@ const scratchCartesian = new Cartesian3();
 function loadObj(objPath, options) {
   const axisTransform = getAxisTransform(
     options.inputUpAxis,
-    options.outputUpAxis
+    options.outputUpAxis,
   );
 
   // Global store of vertex attributes listed in the obj file
@@ -185,7 +185,7 @@ function loadObj(objPath, options) {
   function correctAttributeIndices(
     attributeIndices,
     attributeData,
-    components
+    components,
   ) {
     const length = attributeIndices.length;
     for (let i = 0; i < length; ++i) {
@@ -195,7 +195,7 @@ function loadObj(objPath, options) {
         attributeIndices[i] = getIndexFromStart(
           attributeIndices[i],
           attributeData,
-          components
+          components,
         );
       }
     }
@@ -206,7 +206,7 @@ function loadObj(objPath, options) {
     for (let i = 0; i < length; ++i) {
       vertices[i] = `${defaultValue(positions[i], "")}/${defaultValue(
         uvs[i],
-        ""
+        "",
       )}/${defaultValue(normals[i], "")}`;
     }
   }
@@ -303,7 +303,7 @@ function loadObj(objPath, options) {
     positionIndex1,
     positionIndex2,
     positionIndex3,
-    normalIndex
+    normalIndex,
   ) {
     if (!defined(normalIndex)) {
       // If no face normal, we have to assume the winding is correct.
@@ -338,7 +338,7 @@ function loadObj(objPath, options) {
     positions,
     uvs,
     normals,
-    triangleWindingOrderSanitization
+    triangleWindingOrderSanitization,
   ) {
     correctAttributeIndices(positions, globalPositions, 3);
     correctAttributeIndices(normals, globalNormals, 3);
@@ -354,7 +354,7 @@ function loadObj(objPath, options) {
           positions[0],
           positions[1],
           positions[2],
-          normals[0]
+          normals[0],
         );
       const index1 = addVertex(vertices[0], positions[0], uvs[0], normals[0]);
       const index2 = addVertex(vertices[1], positions[1], uvs[1], normals[1]);
@@ -382,7 +382,7 @@ function loadObj(objPath, options) {
           points,
           scratchCenter,
           scratchAxis1,
-          scratchAxis2
+          scratchAxis2,
         );
       if (!validGeometry) {
         return;
@@ -391,7 +391,7 @@ function loadObj(objPath, options) {
         CoplanarPolygonGeometryLibrary.createProjectPointsTo2DFunction(
           scratchCenter,
           scratchAxis1,
-          scratchAxis2
+          scratchAxis2,
         );
       const points2D = projectPoints(points);
       const indices = PolygonPipeline.triangulate(points2D);
@@ -404,7 +404,7 @@ function loadObj(objPath, options) {
           vertexIndices[indices[i]],
           vertexIndices[indices[i + 1]],
           vertexIndices[indices[i + 2]],
-          isWindingCorrect
+          isWindingCorrect,
         );
       }
     }
@@ -444,7 +444,7 @@ function loadObj(objPath, options) {
         parseFloat(result[1]),
         parseFloat(result[2]),
         parseFloat(result[3]),
-        scratchNormal
+        scratchNormal,
       );
       if (Cartesian3.equals(normal, Cartesian3.ZERO)) {
         Cartesian3.clone(Cartesian3.UNIT_Z, normal);
@@ -482,7 +482,7 @@ function loadObj(objPath, options) {
             facePositions,
             faceUvs,
             faceNormals,
-            options.triangleWindingOrderSanitization
+            options.triangleWindingOrderSanitization,
           );
         }
 
@@ -511,7 +511,7 @@ function loadObj(objPath, options) {
       mtlPaths,
       objPath,
       defined(activeMaterial),
-      options
+      options,
     );
   });
 }
@@ -574,7 +574,7 @@ function loadMtls(mtlPaths, objPath, options) {
       if (options.secure && outsideDirectory(mtlPath, objDirectory)) {
         // Try looking for the .mtl in the same directory as the obj
         options.logger(
-          "The material file is outside of the obj directory and the secure flag is true. Attempting to read the material file from within the obj directory instead."
+          "The material file is outside of the obj directory and the secure flag is true. Attempting to read the material file from within the obj directory instead.",
         );
         return loadMtl(shallowPath, options)
           .then(function (materialsInMtl) {
@@ -583,7 +583,7 @@ function loadMtls(mtlPaths, objPath, options) {
           .catch(function (error) {
             options.logger(error.message);
             options.logger(
-              `Could not read material file at ${shallowPath}. Using default material instead.`
+              `Could not read material file at ${shallowPath}. Using default material instead.`,
             );
           });
       }
@@ -593,7 +593,7 @@ function loadMtls(mtlPaths, objPath, options) {
           // Try looking for the .mtl in the same directory as the obj
           options.logger(error.message);
           options.logger(
-            `Could not read material file at ${mtlPath}. Attempting to read the material file from within the obj directory instead.`
+            `Could not read material file at ${mtlPath}. Attempting to read the material file from within the obj directory instead.`,
           );
           return loadMtl(shallowPath, options);
         })
@@ -603,11 +603,11 @@ function loadMtls(mtlPaths, objPath, options) {
         .catch(function (error) {
           options.logger(error.message);
           options.logger(
-            `Could not read material file at ${shallowPath}. Using default material instead.`
+            `Could not read material file at ${shallowPath}. Using default material instead.`,
           );
         });
     },
-    { concurrency: 10 }
+    { concurrency: 10 },
   ).then(function () {
     return materials;
   });

--- a/lib/obj2gltf.js
+++ b/lib/obj2gltf.js
@@ -53,43 +53,43 @@ function obj2gltf(objPath, options) {
     options.separate;
   options.checkTransparency = defaultValue(
     options.checkTransparency,
-    defaults.checkTransparency
+    defaults.checkTransparency,
   );
   options.doubleSidedMaterial = defaultValue(
     options.doubleSidedMaterial,
-    defaults.doubleSidedMaterial
+    defaults.doubleSidedMaterial,
   );
   options.secure = defaultValue(options.secure, defaults.secure);
   options.packOcclusion = defaultValue(
     options.packOcclusion,
-    defaults.packOcclusion
+    defaults.packOcclusion,
   );
   options.metallicRoughness = defaultValue(
     options.metallicRoughness,
-    defaults.metallicRoughness
+    defaults.metallicRoughness,
   );
   options.specularGlossiness = defaultValue(
     options.specularGlossiness,
-    defaults.specularGlossiness
+    defaults.specularGlossiness,
   );
   options.unlit = defaultValue(options.unlit, defaults.unlit);
   options.overridingTextures = defaultValue(
     options.overridingTextures,
-    defaultValue.EMPTY_OBJECT
+    defaultValue.EMPTY_OBJECT,
   );
   options.logger = defaultValue(options.logger, getDefaultLogger());
   options.writer = defaultValue(
     options.writer,
-    getDefaultWriter(options.outputDirectory)
+    getDefaultWriter(options.outputDirectory),
   );
   options.inputUpAxis = defaultValue(options.inputUpAxis, defaults.inputUpAxis);
   options.outputUpAxis = defaultValue(
     options.outputUpAxis,
-    defaults.outputUpAxis
+    defaults.outputUpAxis,
   );
   options.triangleWindingOrderSanitization = defaultValue(
     options.triangleWindingOrderSanitization,
-    defaults.triangleWindingOrderSanitization
+    defaults.triangleWindingOrderSanitization,
   );
 
   if (!defined(objPath)) {
@@ -98,7 +98,7 @@ function obj2gltf(objPath, options) {
 
   if (options.separateTextures && !defined(options.writer)) {
     throw new DeveloperError(
-      "Either options.writer or options.outputDirectory must be defined when writing separate resources."
+      "Either options.writer or options.outputDirectory must be defined when writing separate resources.",
     );
   }
 
@@ -107,7 +107,7 @@ function obj2gltf(objPath, options) {
     1
   ) {
     throw new DeveloperError(
-      "Only one material type may be set from [metallicRoughness, specularGlossiness, unlit]."
+      "Only one material type may be set from [metallicRoughness, specularGlossiness, unlit].",
     );
   }
 
@@ -116,7 +116,7 @@ function obj2gltf(objPath, options) {
     defined(options.overridingTextures.specularGlossinessTexture)
   ) {
     throw new DeveloperError(
-      "metallicRoughnessOcclusionTexture and specularGlossinessTexture cannot both be defined."
+      "metallicRoughnessOcclusionTexture and specularGlossinessTexture cannot both be defined.",
     );
   }
 

--- a/lib/writeGltf.js
+++ b/lib/writeGltf.js
@@ -140,7 +140,7 @@ function writeSeparateBuffers(gltf, options) {
       buffer.uri = bufferUri;
       return options.writer(bufferUri, source);
     },
-    { concurrency: 10 }
+    { concurrency: 10 },
   );
 }
 
@@ -154,7 +154,7 @@ function writeSeparateTextures(gltf, options) {
       image.uri = imageUri;
       return options.writer(imageUri, texture.source);
     },
-    { concurrency: 10 }
+    { concurrency: 10 },
   );
 }
 
@@ -165,12 +165,12 @@ function writeEmbeddedBuffer(gltf) {
   // Buffers larger than ~192MB cannot be base64 encoded due to a NodeJS limitation. Source: https://github.com/nodejs/node/issues/4266
   if (source.length > 201326580) {
     throw new RuntimeError(
-      "Buffer is too large to embed in the glTF. Use the --separate flag instead."
+      "Buffer is too large to embed in the glTF. Use the --separate flag instead.",
     );
   }
 
   buffer.uri = `data:application/octet-stream;base64,${source.toString(
-    "base64"
+    "base64",
   )}`;
 }
 

--- a/package.json
+++ b/package.json
@@ -37,21 +37,28 @@
   "devDependencies": {
     "cloc": "^2.8.0",
     "eslint": "^8.0.1",
-    "eslint-config-cesium": "^9.0.0",
-    "eslint-config-prettier": "^8.3.0",
-    "eslint-plugin-node": "^11.1.0",
+    "eslint-config-cesium": "^10.0.1",
+    "eslint-config-prettier": "^9.0.0",
+    "eslint-plugin-n": "^16.1.0",
     "gulp": "^4.0.2",
     "husky": "^8.0.3",
     "jasmine": "^5.0.0",
     "jasmine-spec-reporter": "^7.0.0",
     "jsdoc": "^4.0.0",
     "nyc": "^15.1.0",
-    "prettier": "2.8.8",
-    "pretty-quick": "^3.1.1"
+    "prettier": "3.0.3",
+    "lint-staged": "^14.0.1"
+  },
+  "lint-staged": {
+    "*.(js|ts)": [
+      "eslint --cache --quiet --fix",
+      "prettier --write"
+    ],
+    "*.!(js|ts)": "prettier --write"
   },
   "scripts": {
     "prepare": "husky install",
-    "pre-commit": "eslint && pretty-quick --staged",
+    "pre-commit": "lint-staged",
     "jsdoc": "jsdoc ./lib -R ./README.md -d doc",
     "eslint": "eslint \"./**/*.js\" --cache --quiet",
     "test": "gulp test",
@@ -60,7 +67,6 @@
     "cloc": "gulp cloc",
     "prettier": "prettier --write \"**/*\"",
     "prettier-check": "prettier --check \"**/*\"",
-    "pretty-quick": "pretty-quick",
     "generate-third-party": "gulp generate-third-party"
   },
   "bin": {

--- a/specs/lib/createGltfSpec.js
+++ b/specs/lib/createGltfSpec.js
@@ -121,7 +121,7 @@ describe("createGltf", () => {
         .map((texture) => {
           return texture.index;
         })
-        .sort()
+        .sort(),
     ).toEqual([0, 1, 2, 3, 4]);
     expect(gltf.samplers[0]).toBeDefined();
   });
@@ -255,7 +255,7 @@ describe("createGltf", () => {
         const material = materials[primitive.material];
         if (!defined(primitive.attributes.TEXCOORD_0)) {
           expect(
-            material.pbrMetallicRoughness.baseColorTexture
+            material.pbrMetallicRoughness.baseColorTexture,
           ).toBeUndefined();
         }
       }

--- a/specs/lib/loadMtlSpec.js
+++ b/specs/lib/loadMtlSpec.js
@@ -61,7 +61,7 @@ describe("loadMtl", () => {
     diffuseTexture = await loadTexture(diffuseTexturePath, decodeOptions);
     transparentDiffuseTexture = await loadTexture(
       transparentDiffuseTexturePath,
-      checkTransparencyOptions
+      checkTransparencyOptions,
     );
     alphaTexture = await loadTexture(alphaTexturePath, decodeOptions);
     ambientTexture = await loadTexture(ambientTexturePath);
@@ -70,7 +70,7 @@ describe("loadMtl", () => {
     specularTexture = await loadTexture(specularTexturePath, decodeOptions);
     specularShininessTexture = await loadTexture(
       specularShininessTexturePath,
-      decodeOptions
+      decodeOptions,
     );
   });
 
@@ -196,12 +196,12 @@ describe("loadMtl", () => {
       spy.calls
         .argsFor(0)[0]
         .indexOf(
-          "Texture file is outside of the mtl directory and the secure flag is true. Attempting to read the texture file from within the obj directory instead"
-        ) >= 0
+          "Texture file is outside of the mtl directory and the secure flag is true. Attempting to read the texture file from within the obj directory instead",
+        ) >= 0,
     ).toBe(true);
     expect(spy.calls.argsFor(1)[0].indexOf("ENOENT") >= 0).toBe(true);
     expect(
-      spy.calls.argsFor(2)[0].indexOf("Could not read texture file") >= 0
+      spy.calls.argsFor(2)[0].indexOf("Could not read texture file") >= 0,
     ).toBe(true);
   });
 
@@ -294,7 +294,7 @@ describe("loadMtl", () => {
           specularTexture: specularTexture,
           specularShininessTexture: specularShininessTexture,
         },
-        options
+        options,
       );
 
       const pbr = material.pbrMetallicRoughness;
@@ -321,7 +321,7 @@ describe("loadMtl", () => {
           specularTexture: specularTexture,
           specularShininessTexture: specularShininessTexture,
         },
-        options
+        options,
       );
 
       const pbr = material.pbrMetallicRoughness;
@@ -339,7 +339,7 @@ describe("loadMtl", () => {
           specularTexture: specularTexture,
           specularShininessTexture: specularShininessTexture,
         },
-        options
+        options,
       );
 
       const pbr = material.pbrMetallicRoughness;
@@ -354,7 +354,7 @@ describe("loadMtl", () => {
         {
           diffuseTexture: transparentDiffuseTexture,
         },
-        options
+        options,
       );
       expect(material.alphaMode).toBe("BLEND");
       expect(material.doubleSided).toBe(true);
@@ -368,7 +368,7 @@ describe("loadMtl", () => {
           diffuseTexture: diffuseTexture,
           alphaTexture: alphaTexture,
         },
-        options
+        options,
       );
 
       const pbr = material.pbrMetallicRoughness;
@@ -398,7 +398,7 @@ describe("loadMtl", () => {
           diffuseTexture: diffuseTexture,
           alphaTexture: diffuseTexture,
         },
-        options
+        options,
       );
 
       const pbr = material.pbrMetallicRoughness;
@@ -446,7 +446,7 @@ describe("loadMtl", () => {
           specularTexture: specularTexture,
           specularShininessTexture: specularShininessTexture,
         },
-        options
+        options,
       );
 
       const pbr = material.extensions.KHR_materials_pbrSpecularGlossiness;
@@ -471,7 +471,7 @@ describe("loadMtl", () => {
           specularTexture: ambientTexture, // Is a .gif which can't be decoded
           specularShininessTexture: specularShininessTexture,
         },
-        options
+        options,
       );
 
       const pbr = material.extensions.KHR_materials_pbrSpecularGlossiness;
@@ -485,7 +485,7 @@ describe("loadMtl", () => {
         {
           diffuseTexture: transparentDiffuseTexture,
         },
-        options
+        options,
       );
 
       expect(material.alphaMode).toBe("BLEND");
@@ -500,7 +500,7 @@ describe("loadMtl", () => {
           diffuseTexture: diffuseTexture,
           alphaTexture: alphaTexture,
         },
-        options
+        options,
       );
 
       const pbr = material.extensions.KHR_materials_pbrSpecularGlossiness;
@@ -530,7 +530,7 @@ describe("loadMtl", () => {
           diffuseTexture: diffuseTexture,
           alphaTexture: diffuseTexture,
         },
-        options
+        options,
       );
 
       const pbr = material.extensions.KHR_materials_pbrSpecularGlossiness;

--- a/specs/lib/loadObjSpec.js
+++ b/specs/lib/loadObjSpec.js
@@ -151,14 +151,14 @@ describe("loadObj", () => {
         normalX,
         normalY,
         normalZ,
-        scratchNormal
+        scratchNormal,
       );
       expect(
         CesiumMath.equalsEpsilon(
           Cartesian3.magnitude(normal),
           1.0,
-          CesiumMath.EPSILON5
-        )
+          CesiumMath.EPSILON5,
+        ),
       ).toBe(true);
     }
   });
@@ -177,7 +177,7 @@ describe("loadObj", () => {
       await loadObj(objNegativeIndicesPath, options),
     ];
     const positionsReference = getPrimitives(
-      results[0]
+      results[0],
     )[0].positions.toFloatBuffer();
     const positions = getPrimitives(results[1])[0].positions.toFloatBuffer();
     expect(positions).toEqual(positionsReference);
@@ -402,18 +402,18 @@ describe("loadObj", () => {
     expect(data.materials.length).toBe(0);
     expect(spy.calls.argsFor(0)[0].indexOf("ENOENT") >= 0).toBe(true);
     expect(spy.calls.argsFor(0)[0].indexOf(path.resolve("/box.mtl")) >= 0).toBe(
-      true
+      true,
     );
     expect(
       spy.calls
         .argsFor(1)[0]
         .indexOf(
-          "Attempting to read the material file from within the obj directory instead."
-        ) >= 0
+          "Attempting to read the material file from within the obj directory instead.",
+        ) >= 0,
     ).toBe(true);
     expect(spy.calls.argsFor(2)[0].indexOf("ENOENT") >= 0).toBe(true);
     expect(
-      spy.calls.argsFor(3)[0].indexOf("Could not read material file") >= 0
+      spy.calls.argsFor(3)[0].indexOf("Could not read material file") >= 0,
     ).toBe(true);
   });
 
@@ -454,12 +454,12 @@ describe("loadObj", () => {
       spy.calls
         .argsFor(0)[0]
         .indexOf(
-          "The material file is outside of the obj directory and the secure flag is true. Attempting to read the material file from within the obj directory instead."
-        ) >= 0
+          "The material file is outside of the obj directory and the secure flag is true. Attempting to read the material file from within the obj directory instead.",
+        ) >= 0,
     ).toBe(true);
     expect(spy.calls.argsFor(1)[0].indexOf("ENOENT") >= 0).toBe(true);
     expect(
-      spy.calls.argsFor(2)[0].indexOf("Could not read material file") >= 0
+      spy.calls.argsFor(2)[0].indexOf("Could not read material file") >= 0,
     ).toBe(true);
   });
 
@@ -505,18 +505,18 @@ describe("loadObj", () => {
     expect(baseColorTexture).toBeUndefined();
     expect(spy.calls.argsFor(0)[0].indexOf("ENOENT") >= 0).toBe(true);
     expect(
-      spy.calls.argsFor(0)[0].indexOf(path.resolve("/cesium.png")) >= 0
+      spy.calls.argsFor(0)[0].indexOf(path.resolve("/cesium.png")) >= 0,
     ).toBe(true);
     expect(
       spy.calls
         .argsFor(1)[0]
         .indexOf(
-          "Attempting to read the texture file from within the obj directory instead."
-        ) >= 0
+          "Attempting to read the texture file from within the obj directory instead.",
+        ) >= 0,
     ).toBe(true);
     expect(spy.calls.argsFor(2)[0].indexOf("ENOENT") >= 0).toBe(true);
     expect(
-      spy.calls.argsFor(3)[0].indexOf("Could not read texture file") >= 0
+      spy.calls.argsFor(3)[0].indexOf("Could not read texture file") >= 0,
     ).toBe(true);
   });
 
@@ -562,7 +562,7 @@ describe("loadObj", () => {
     return new Cartesian3(
       primitive.positions.get(0),
       primitive.positions.get(1),
-      primitive.positions.get(2)
+      primitive.positions.get(2),
     );
   }
 
@@ -571,7 +571,7 @@ describe("loadObj", () => {
     return new Cartesian3(
       primitive.normals.get(0),
       primitive.normals.get(1),
-      primitive.normals.get(2)
+      primitive.normals.get(2),
     );
   }
 
@@ -579,7 +579,7 @@ describe("loadObj", () => {
     inputUpAxis,
     outputUpAxis,
     position,
-    normal
+    normal,
   ) {
     const sameAxis = inputUpAxis === outputUpAxis;
     options.inputUpAxis = inputUpAxis;
@@ -629,13 +629,13 @@ describe("loadObj", () => {
     options.triangleWindingOrderSanitization = false;
     const indicesIncorrect = await loadAndGetIndices(
       objIncorrectWindingOrderPath,
-      options
+      options,
     );
 
     options.triangleWindingOrderSanitization = true;
     const indicesCorrect = await loadAndGetIndices(
       objIncorrectWindingOrderPath,
-      options
+      options,
     );
 
     expect(indicesIncorrect[0]).toBe(0);
@@ -655,7 +655,7 @@ describe("loadObj", () => {
       thrownError = e;
     }
     expect(thrownError).toEqual(
-      new RuntimeError("Position index 1 is out of bounds")
+      new RuntimeError("Position index 1 is out of bounds"),
     );
   });
 
@@ -667,7 +667,7 @@ describe("loadObj", () => {
       thrownError = e;
     }
     expect(thrownError).toEqual(
-      new RuntimeError("Normal index 1 is out of bounds")
+      new RuntimeError("Normal index 1 is out of bounds"),
     );
   });
 
@@ -679,7 +679,7 @@ describe("loadObj", () => {
       thrownError = e;
     }
     expect(thrownError).toEqual(
-      new RuntimeError("UV index 1 is out of bounds")
+      new RuntimeError("UV index 1 is out of bounds"),
     );
   });
 
@@ -692,8 +692,8 @@ describe("loadObj", () => {
     }
     expect(thrownError).toEqual(
       new RuntimeError(
-        `${objInvalidContentsPath} does not have any geometry data`
-      )
+        `${objInvalidContentsPath} does not have any geometry data`,
+      ),
     );
   });
 
@@ -705,7 +705,7 @@ describe("loadObj", () => {
       thrownError = e;
     }
     expect(
-      thrownError.message.startsWith("ENOENT: no such file or directory")
+      thrownError.message.startsWith("ENOENT: no such file or directory"),
     ).toBe(true);
   });
 });

--- a/specs/lib/obj2gltfSpec.js
+++ b/specs/lib/obj2gltfSpec.js
@@ -168,8 +168,8 @@ describe("obj2gltf", () => {
     }
     expect(thrownError).toEqual(
       new DeveloperError(
-        "Either options.writer or options.outputDirectory must be defined when writing separate resources."
-      )
+        "Either options.writer or options.outputDirectory must be defined when writing separate resources.",
+      ),
     );
   });
 
@@ -187,8 +187,8 @@ describe("obj2gltf", () => {
     }
     expect(thrownError).toEqual(
       new DeveloperError(
-        "Only one material type may be set from [metallicRoughness, specularGlossiness, unlit]."
-      )
+        "Only one material type may be set from [metallicRoughness, specularGlossiness, unlit].",
+      ),
     );
   });
 
@@ -208,8 +208,8 @@ describe("obj2gltf", () => {
     }
     expect(thrownError).toEqual(
       new DeveloperError(
-        "metallicRoughnessOcclusionTexture and specularGlossinessTexture cannot both be defined."
-      )
+        "metallicRoughnessOcclusionTexture and specularGlossinessTexture cannot both be defined.",
+      ),
     );
   });
 });


### PR DESCRIPTION
This is all internal dev stuff, not need to publish a new version or otherwise update anything.

* Upgrade prettier to 3.0.3 and format files.
* Upgrade `eslint-config-cesium` and `eslint-config-prettier`.
* Switch from the defunct `eslint-plugin-node` to `eslint-plugin-n` Since that is what `eslint-config-cesium` now uses.
* Switch from pretty-quick to lint-staged