### PR TITLE
Remove double quotes in the mtl and texture paths

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ### 3.2.0 - 2023-??-??
 
 - Added `doubleSidedMaterial` option to force materials to be rendered double sided. [#294](https://github.com/CesiumGS/obj2gltf/pull/294)
+- Strip file paths of any enclosing double-quotes to allow the mtl/texture files to be properly parsed [#297](https://github.com/CesiumGS/obj2gltf/pull/297)
 
 ### 3.1.6 - 2023-02-10
 

--- a/lib/loadMtl.js
+++ b/lib/loadMtl.js
@@ -101,6 +101,8 @@ function loadMtl(mtlPath, options) {
   }
 
   function normalizeTexturePath(texturePath, mtlDirectory) {
+    //Remove double quotes around the texture file if it exists
+    texturePath = texturePath.replace(/^"(.+)"$/, "$1");
     // Removes texture options from texture name
     // Assumes no spaces in texture name
     const re = /-(bm|t|s|o|blendu|blendv|boost|mm|texres|clamp|imfchan|type)/;

--- a/lib/loadObj.js
+++ b/lib/loadObj.js
@@ -519,6 +519,8 @@ function loadObj(objPath, options) {
 function getMtlPaths(mtllibLine) {
   // Handle paths with spaces. E.g. mtllib my material file.mtl
   const mtlPaths = [];
+  //Remove double quotes around the mtl file if it exists
+  mtllibLine = mtllibLine.replace(/^"(.+)"$/, "$1");
   const splits = mtllibLine.split(" ");
   const length = splits.length;
   let startIndex = 0;

--- a/package.json
+++ b/package.json
@@ -45,9 +45,9 @@
     "jasmine": "^5.0.0",
     "jasmine-spec-reporter": "^7.0.0",
     "jsdoc": "^4.0.0",
+    "lint-staged": "^14.0.1",
     "nyc": "^15.1.0",
-    "prettier": "3.0.3",
-    "lint-staged": "^14.0.1"
+    "prettier": "3.0.3"
   },
   "lint-staged": {
     "*.(js|ts)": [


### PR DESCRIPTION
If the mtl and/or texture paths are enclosed in double-quotes, they will fail to be read.

For example, if within the`obj` file, the mtl path is defined as follows:

`mtllib "OBJ - Berlin Bridge.mtl"`

The `mtl` file will not be loaded because when we try to compare the extension of the file to confirm that it ends with `.mtl`, that fails because the last token is `.mtl"`

The same thing happens to texture files.

This pull request strips the mtl and texture file of its double quotes if they exists. If they don't , nothing happens. 

There is at least one OBJ export tool (metashape from agisoft) that adds double quotes to filemanes that contains spaces in them.

This pull request sould fix this isse.

