### PR TITLE
Update prettier

### DIFF
--- a/lib/loadMtl.js
+++ b/lib/loadMtl.js
@@ -70,8 +70,8 @@ function loadMtl(mtlPath, options) {
   const ambientTextureOptions = defined(overridingAmbientTexture)
     ? undefined
     : options.packOcclusion
-    ? decodeOptions
-    : undefined;
+      ? decodeOptions
+      : undefined;
   const specularTextureOptions = defined(overridingSpecularTexture)
     ? undefined
     : decodeOptions;

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "jsdoc": "^4.0.0",
     "lint-staged": "^15.0.2",
     "nyc": "^15.1.0",
-    "prettier": "3.0.3"
+    "prettier": "3.1.1"
   },
   "lint-staged": {
     "*.(js|ts)": [


### PR DESCRIPTION
Updates prettier to latest version.

The only library pinned here is mime because it requires ESM. Opened https://github.com/CesiumGS/obj2gltf/issues/301 and created new label for dependency updates