### PR TITLE
Remove buffer length limit

### DIFF
--- a/lib/writeGltf.js
+++ b/lib/writeGltf.js
@@ -162,13 +162,6 @@ function writeEmbeddedBuffer(gltf) {
   const buffer = gltf.buffers[0];
   const source = buffer.extras._obj2gltf.source;
 
-  // Buffers larger than ~192MB cannot be base64 encoded due to a NodeJS limitation. Source: https://github.com/nodejs/node/issues/4266
-  if (source.length > 201326580) {
-    throw new RuntimeError(
-      "Buffer is too large to embed in the glTF. Use the --separate flag instead.",
-    );
-  }
-
   buffer.uri = `data:application/octet-stream;base64,${source.toString(
     "base64",
   )}`;


### PR DESCRIPTION
Previously there was a hard-coded limit of `192MB` for the buffer length, preventing the library from processing larger files. The comment in the code mentioned the [issue in NodeJS](https://github.com/nodejs/node/issues/4266) which was resolved in 2016 for Node 0.12 (which has reached its EOL long-long ago).

There is sort of a workaround for this limitation by using the `separate` and `separateTextures` options, but they are not 
always a suitable solution.

This change address #59 .