### PR TITLE
Fix Default Value Errors

### DIFF
--- a/bin/obj2gltf.js
+++ b/bin/obj2gltf.js
@@ -6,7 +6,7 @@ const path = require("path");
 const yargs = require("yargs");
 const obj2gltf = require("../lib/obj2gltf");
 
-const defaultValue = Cesium.defaultValue;
+const defaultValue = (a, b) => a ?? b;
 const defined = Cesium.defined;
 
 const defaults = obj2gltf.defaults;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,7 +10,7 @@ const JasmineSpecReporter = require("jasmine-spec-reporter").SpecReporter;
 const path = require("path");
 const yargs = require("yargs");
 
-const defaultValue = Cesium.defaultValue;
+const defaultValue = (a, b) => a ?? b;
 const defined = Cesium.defined;
 const argv = yargs.argv;
 
@@ -119,7 +119,7 @@ function cloc() {
 }
 
 function getLicenseDataFromPackage(packageName, override) {
-  override = defaultValue(override, defaultValue.EMPTY_OBJECT);
+  override = defaultValue(override, Cesium.Frozen.EMPTY_OBJECT);
   const packagePath = path.join("node_modules", packageName, "package.json");
 
   if (!fsExtra.existsSync(packagePath)) {

--- a/lib/createGltf.js
+++ b/lib/createGltf.js
@@ -7,7 +7,7 @@ const getBufferPadded = require("./getBufferPadded");
 const getDefaultMaterial = require("./loadMtl").getDefaultMaterial;
 const Texture = require("./Texture");
 
-const defaultValue = Cesium.defaultValue;
+const defaultValue = (a, b) => a ?? b;
 const defined = Cesium.defined;
 const WebGLConstants = Cesium.WebGLConstants;
 

--- a/lib/loadMtl.js
+++ b/lib/loadMtl.js
@@ -10,7 +10,7 @@ const Texture = require("./Texture");
 const CesiumMath = Cesium.Math;
 const clone = Cesium.clone;
 const combine = Cesium.combine;
-const defaultValue = Cesium.defaultValue;
+const defaultValue = (a, b) => a ?? b;
 const defined = Cesium.defined;
 
 module.exports = loadMtl;

--- a/lib/loadObj.js
+++ b/lib/loadObj.js
@@ -12,7 +12,7 @@ const Axis = Cesium.Axis;
 const Cartesian3 = Cesium.Cartesian3;
 const ComponentDatatype = Cesium.ComponentDatatype;
 const CoplanarPolygonGeometryLibrary = Cesium.CoplanarPolygonGeometryLibrary;
-const defaultValue = Cesium.defaultValue;
+const defaultValue = (a, b) => a ?? b;
 const defined = Cesium.defined;
 const PolygonPipeline = Cesium.PolygonPipeline;
 const RuntimeError = Cesium.RuntimeError;

--- a/lib/loadTexture.js
+++ b/lib/loadTexture.js
@@ -7,7 +7,7 @@ const PNG = require("pngjs").PNG;
 const Promise = require("bluebird");
 const Texture = require("./Texture");
 
-const defaultValue = Cesium.defaultValue;
+const defaultValue = (a, b) => a ?? b;
 const defined = Cesium.defined;
 
 module.exports = loadTexture;

--- a/lib/obj2gltf.js
+++ b/lib/obj2gltf.js
@@ -6,7 +6,7 @@ const createGltf = require("./createGltf");
 const loadObj = require("./loadObj");
 const writeGltf = require("./writeGltf");
 
-const defaultValue = Cesium.defaultValue;
+const defaultValue = (a, b) => a ?? b;
 const defined = Cesium.defined;
 const DeveloperError = Cesium.DeveloperError;
 
@@ -75,7 +75,7 @@ function obj2gltf(objPath, options) {
   options.unlit = defaultValue(options.unlit, defaults.unlit);
   options.overridingTextures = defaultValue(
     options.overridingTextures,
-    defaultValue.EMPTY_OBJECT,
+    Cesium.Frozen.EMPTY_OBJECT,
   );
   options.logger = defaultValue(options.logger, getDefaultLogger());
   options.writer = defaultValue(


### PR DESCRIPTION
Cesium Dropped support for defaultValue as js supports `??` with the same effect.

This replaced the defaultValue function with one that does the same thing.